### PR TITLE
ci: replace 'create-release action' with gh cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,13 @@ jobs:
 
       # Create release
       - if: "steps.tag.outputs.value != ''"
-        run: |
-          gh release create ${{ steps.tag.outputs.value }} -t "Release ${{ steps.tag.outputs.value }}" --notes "${{ steps.bumpr.outputs.message }}"
         env:
+          TAG_NAME: ${{ steps.tag.outputs.value }}
+          BODY: ${{ steps.bumpr.outputs.message }}
           # This token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${TAG_NAME}" -t "Release ${TAG_NAME}" --notes "${BODY}"
 
   release-check:
     if: github.event.action == 'labeled'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
   pull_request:
     types:
       - labeled
@@ -37,17 +37,13 @@ jobs:
           if_true: ${{ github.ref }}
           if_false: ${{ steps.bumpr.outputs.next_version }}
 
-      # Create release.
-      - uses: shogo82148/actions-create-release@v1
-        if: "steps.tag.outputs.value != ''"
-        with:
+      # Create release
+      - if: "steps.tag.outputs.value != ''"
+        run: |
+          gh release create ${{ steps.tag.outputs.value }} -t "Release ${{ steps.tag.outputs.value }}" --notes "${{ steps.bumpr.outputs.message }}"
+        env:
           # This token is provided by Actions, you do not need to create your own token
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: ${{ steps.tag.outputs.value }}
-          release_name: Release ${{ steps.tag.outputs.value }}
-          body: ${{ steps.bumpr.outputs.message }}
-          draft: false
-          prerelease: false
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-check:
     if: github.event.action == 'labeled'


### PR DESCRIPTION
This commit replaces the [create-release action](https://github.com/actions/create-release) since this action was depricated. See https://github.com/reviewdog/reviewdog/issues/1043 for the full discussion.
