### PR TITLE
style(shfmt): Add .editorconfig file to respect style of existing code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.sh]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
Hi! Thank you for a pretty code review tool 🐶

Inspired by this great tool, I just built and published [a GitHub Action](https://github.com/blooper05/action-rails_best_practices) based on this template.
This PR is my own suggestion for improvement to what I have noticed in using this template in that work.

The great thing about this is that `shfmt` is set up with CI 👏 
However, when I clone this repository and immediately run the `shfmt --write script.sh` command, I get a diff there.
This is due to the fact that shfmt defaults to tabs indentation.
refs: <https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd#printer-flags>

The existing code is indented by 2 spaces, so I have configured `shfmt` to respect that.

Please check my changes and merge them if you like it. Thanks!