### PR TITLE
Add GitHub Actions permissions and signed commits

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -9,8 +9,16 @@ on:
 jobs:
   reviewdog:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Enable OIDC
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # Configure signed commits
+      # https://www.chainguard.dev/unchained/keyless-git-commit-signing-with-gitsign-and-github-actions
+      # https://github.com/chainguard-dev/actions/commits/main/setup-gitsign
+      - uses: chainguard-dev/actions/setup-gitsign@141bf225e9c19c34304ee9d06e9be9c44a6d8765 # main branch as of 2024-12-27
       - uses: reviewdog/action-depup/with-pr@94a1aaf4e4923064019214b48a43276218af7ad5 # v1.6.4
         with:
           file: action.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,14 @@ jobs:
   release:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Enable OIDC
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      # Configure signed tags
+      # https://www.chainguard.dev/unchained/keyless-git-commit-signing-with-gitsign-and-github-actions
+      # https://github.com/chainguard-dev/actions/commits/main/setup-gitsign
+      - uses: chainguard-dev/actions/setup-gitsign@141bf225e9c19c34304ee9d06e9be9c44a6d8765 # main branch as of 2024-12-27
 
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
   steps:
     - uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
       with:
-        reviewdog_version: v0.20.2 # test
+        reviewdog_version: v0.20.3
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
   steps:
     - uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
       with:
-        reviewdog_version: v0.20.3
+        reviewdog_version: v0.20.2 # test
     - run: $GITHUB_ACTION_PATH/script.sh
       shell: bash
       env:


### PR DESCRIPTION
## Summary
- Add proper GitHub Actions workflow permissions for OIDC, pull requests, and contents
- Add gitsign setup for keyless Git commit signing
- Uses Chainguard's setup-gitsign action to enable secure commits

## Test plan
- Workflow should run and be able to create signed commits in PRs

🤖 Generated with [Claude Code](https://claude.ai/code)